### PR TITLE
Show serialization with pickle

### DIFF
--- a/pytvdbapi/api.py
+++ b/pytvdbapi/api.py
@@ -179,6 +179,9 @@ class Episode(object):
 
     .. _thetvdb.com: http://thetvdb.com
     """
+
+    data = {}
+
     def __init__(self, data, season, config):
         self.season, self.config = season, config
         ignore_case = self.config.get('ignore_case', False)
@@ -358,6 +361,9 @@ class Show(Mapping):
 
     .. _thetvdb.com: http://thetvdb.com
     """
+
+    data = {}
+
     def __init__(self, data, api, language, config):
         self.api, self.lang, self.config = api, language, config
         self.seasons = dict()

--- a/pytvdbapi/error.py
+++ b/pytvdbapi/error.py
@@ -57,7 +57,7 @@ class ConnectionError(PytvdbapiError):
     pass
 
 
-class TVDBAttributeError(PytvdbapiError):
+class TVDBAttributeError(PytvdbapiError, AttributeError):
     """
     A replacement for the standard AttributeError. Will be raised when
     accessing invalid attributes of :class:`pytvdbapi.api.Show` and :class:`pytvdbapi.api.Episode`

--- a/pytvdbapi/tests/test_api.py
+++ b/pytvdbapi/tests/test_api.py
@@ -175,6 +175,19 @@ class TestShow(unittest.TestCase):
         self.assertTrue('seasons' in dir(friends), "Show should have a seasons attribute")
         self.assertTrue('api' in dir(friends), "Show should have an api attribute")
 
+    def test_show_pickle(self):
+        """It should be possible to pickle and unpickle a fully loaded show"""
+
+        import pickle
+
+        friends = _load_show("friends")
+        friends.update()
+
+        pickled_show = pickle.dumps(friends)
+        loaded_show = pickle.loads(pickled_show)
+
+        self.assertTrue(loaded_show.SeriesName == friends.SeriesName, "Show should keep its lang attribute")
+
     def test_iterate_show(self):
         """It should be possible to iterate over the show to get all seasons"""
         friends = _load_show("friends")


### PR DESCRIPTION
It would be great to be able to pickle Show instances, in order to store those directly in cache instead of parsing XML files every time.
