### PR TITLE
Reduce exceptions verbosity

### DIFF
--- a/pytvdbapi/api.py
+++ b/pytvdbapi/api.py
@@ -192,7 +192,6 @@ class Episode(object):
         try:
             return self.data[item]
         except KeyError:
-            logger.error("Episode has no attribute {0}".format(item))
             raise error.TVDBAttributeError("Episode has no attribute {0}".format(item))
 
     def __dir__(self):
@@ -255,7 +254,6 @@ class Season(Mapping):
         try:
             return self.episodes[item]
         except KeyError:
-            logger.error("Episode {0} not found".format(item))
             raise error.TVDBIndexError("Index {0} not found".format(item))
 
     def __len__(self):
@@ -733,7 +731,6 @@ class TVDB(object):
         try:
             data = self.loader.load(url, cache)
         except error.TVDBNotFoundError:
-            logger.debug("Id {0} not found".format(series_id))
             raise error.TVDBIdError("Series id {0} not found".format(series_id))
         except error.ConnectionError as _error:
             logger.debug("Unable to connect to URL: {0}. {1}".format(url, _error))
@@ -742,7 +739,6 @@ class TVDB(object):
         if data.strip():
             data = generate_tree(data)
         else:
-            logger.debug("Empty data received for id {0}".format(series_id))
             raise error.TVDBIdError("No Show with id {0} found".format(series_id))
 
         series = parse_xml(data, "Series")
@@ -807,7 +803,6 @@ class TVDB(object):
         if data.strip():
             data = generate_tree(data)
         else:
-            logger.debug("Empty data received for id {0}".format(episode_id))
             raise error.TVDBIdError("No Episode with id {0} found".format(episode_id))
 
         episodes = parse_xml(data, "Episode")


### PR DESCRIPTION
All created exception already log its message. There is no need to log it beforehand.
Exemple:

``` python
import logging
logging.basicConfig(level=logging.DEBUG)

try:
    season[42]
    # ERROR:pytvdbapi.api:Episode 42 not found
    # ERROR:pytvdbapi.error:Index 42 not found
except:
    pass

try:
    episode.foooo
    # ERROR:pytvdbapi.api:Episode has no attribute foooo
    # ERROR:pytvdbapi.error:Episode has no attribute foooo
except:
    pass

print hasattr(episode, 'foooo')
# ERROR:pytvdbapi.api:Episode has no attribute foooo
# ERROR:pytvdbapi.error:Episode has no attribute foooo
```
