### PR TITLE
Added support for httplib2 timeouts.

### DIFF
--- a/pytvdbapi/api.py
+++ b/pytvdbapi/api.py
@@ -593,6 +593,10 @@ class TVDB(object):
       case insensitive manner. If set to False, the default, all
       attributes will be case sensitive and retain the same casing
       as provided by `thetvdb.com <http://thetvdb.com>`_.
+
+    * **timeout** (default=None) When set to a number, will cause the http
+    request to timeout after that number of seconds.
+
     """
 
     @unicode_arguments
@@ -612,7 +616,7 @@ class TVDB(object):
         self.config['ignore_case'] = kwargs.get('ignore_case', False)
 
         # Create the loader object to use
-        self.loader = Loader(self.config['cache_dir'])
+        self.loader = Loader(self.config['cache_dir'], timeout=kwargs.get('timeout', None))
 
         # Create the list of available mirrors
         tree = generate_tree(self.loader.load(mirrors.format(**self.config)))

--- a/pytvdbapi/loader.py
+++ b/pytvdbapi/loader.py
@@ -41,8 +41,9 @@ class Loader(object):
     Uses httplib2 to do the heavy lifting.
     """
 
-    def __init__(self, cache_path):
-        self.http = httplib2.Http(cache=os.path.abspath(cache_path))
+    def __init__(self, cache_path, timeout=None):
+        self.http = httplib2.Http(cache=os.path.abspath(cache_path),
+                                  timeout=timeout)
 
     def load(self, url, cache=True):
         """


### PR DESCRIPTION
Now you can do:
    tv = TVDB(api_key, timeout=2)
And the search method will respect that timeout and produce an appropriate exception.
